### PR TITLE
Remove PDF preview from editor

### DIFF
--- a/BlazorWebApp/Components/Pages/Editor.razor
+++ b/BlazorWebApp/Components/Pages/Editor.razor
@@ -104,10 +104,6 @@
       {
         <MudProgressLinear Indeterminate="true" Class="mt-2" />
       }
-      @if (dto.PdfFileId != null)
-      {
-        <iframe src="/api/files/@dto.PdfFileId/document.pdf" style="width:100%; height:70vh; border:none;"></iframe>
-      }
     </div>
   }
 


### PR DESCRIPTION
## Summary
- stop showing the uploaded PDF preview in Editor page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879b784b9bc8322998918b26f3cead3